### PR TITLE
added spec to istioCNI to match the helm chart

### DIFF
--- a/clusters/crc-canary-upgrade/overlays/ossm3-istio-system/values.yaml
+++ b/clusters/crc-canary-upgrade/overlays/ossm3-istio-system/values.yaml
@@ -1,6 +1,7 @@
 istioCNI:
-  version: v1.24.3
-  namespace: istio-cni
+  spec:
+    version: v1.24.3
+    namespace: istio-cni
 # https://istio.io/latest/docs/setup/upgrade/canary/
 istioRevisionTags: 
   # https://istio.io/latest/docs/setup/upgrade/canary/#default-tag


### PR DESCRIPTION
Adding the spec field in the values to match the helm chart used. Otherwise some of the versions don't match up correctly